### PR TITLE
Remove ArrayList extension

### DIFF
--- a/src/oops/SOLID/lsp/stack/before/StackWrong.java
+++ b/src/oops/SOLID/lsp/stack/before/StackWrong.java
@@ -14,19 +14,20 @@ import java.util.ArrayList;
  * so objects of ArrayList are not fully replaceable by the objects of stack.   
  * 
  */
-public class StackWrong extends ArrayList<Integer>{
+public class StackWrong {
 	private int topPointer = 0;
-	
+	private ArrayList<Integer> E;
+		
 	public void push(Integer a) {
-		add(topPointer, a);
+		E.add(topPointer, a);
 		topPointer++;
 	}	
 	public void pop() {
-		remove(topPointer-1);
+		E.remove(topPointer-1);
 		topPointer--;
 	}
 	public Integer top() {
-		return get(topPointer-1);
+		return E.get(topPointer-1);
 	}
 	
 	public static void main(String[] args) {
@@ -36,7 +37,7 @@ public class StackWrong extends ArrayList<Integer>{
 		System.out.println(st.top());
 		st.pop();
 		System.out.println(st.top());
-		st.clear();
+		//st.clear();
 		System.out.println(st.top());
 	}
 }


### PR DESCRIPTION
Modified to remove the ArrayList extension by the stack class. Instead, it contains an ArrayList object.
With this modification, we will not be able to use the st.clear() method.